### PR TITLE
Change release test to workflow dispatch

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -1,8 +1,7 @@
 name: Release Test
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
 
 jobs:
 


### PR DESCRIPTION
### What
Change release test to workflow dispatch.

### Why
Unfortunately the workflow cannot be automatically triggered because the release is created in a workflow, and releases created from workflows are not allowed to kick off other workflows.