### PR TITLE
Fix cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/checkout@v3
     - shell: bash
       run: rustup update
-    - uses: stellar/actions/rust-cache@cachesupportmac
+    - uses: stellar/actions/rust-cache@main
     - shell: bash
       run: cargo install --target-dir ~/.cargo/target --root . --locked --version ${{ matrix.crate.version }} ${{ matrix.crate.name }}
     - shell: bash


### PR DESCRIPTION
### What
Update the branch of the rust-cache plugin to use.

### Why
I forgot to update it when merging the last PR, and now the main branch build is broken because it is trying to download a branch that doens't exist.