### PR TITLE
Fix ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ specified as a tag, as the tag also identifies which release to download the
 binaries from.
 
 ```yml
-- uses: stellar/binaries@v7
+- uses: stellar/binaries@v10
   with:
     name: cargo-set-rust-version
     version: 0.5.0

--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ runs:
   - shell: bash
     run: |
       file="${{ inputs.name }}-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}.tar.gz"
-      ref="${{ inputs.ref || github.ref_name }}"
+      ref="${{ inputs.ref || github.action_ref }}"
       curl -fL https://github.com/stellar/binaries/releases/download/$ref/$file | tar xvz -C $HOME/.local/bin


### PR DESCRIPTION
### What
Change ref used to download the release to be the action ref rather than the workflows ref.

### Why
The ref / version on the end of the action is the thing that should be used to decide what release to download from.