### PR TITLE
Fix ref

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,9 @@ runs:
       mkdir -p $HOME/.local/bin
       echo "$HOME/.local/bin" >> $GITHUB_PATH
   - shell: bash
+    env:
+      REF: ${{ github.action_ref }}
     run: |
       file="${{ inputs.name }}-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}.tar.gz"
-      ref="${{ inputs.ref || github.action_ref }}"
+      ref="${{ inputs.ref || $REF }}"
       curl -fL https://github.com/stellar/binaries/releases/download/$ref/$file | tar xvz -C $HOME/.local/bin

--- a/action.yml
+++ b/action.yml
@@ -20,5 +20,5 @@ runs:
       REF: ${{ github.action_ref }}
     run: |
       file="${{ inputs.name }}-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}.tar.gz"
-      ref="${{ inputs.ref || $REF }}"
+      ref="${{ inputs.ref || env.REF }}"
       curl -fL https://github.com/stellar/binaries/releases/download/$ref/$file | tar xvz -C $HOME/.local/bin


### PR DESCRIPTION
### What
Collect ref via an env var.

### Why
The ref is blank when it should have a value. According to https://github.com/orgs/community/discussions/25283 the `githug.action_ref` value is only available in certain contexts. It's available at the level of setting values in the yml, but not in the scripts. 