### PR TITLE
Add cargo-edit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,8 @@ jobs:
           version: '0.5.16'
         - name: cargo-set-rust-version
           version: '0.5.0'
+        - name: cargo-edit
+          version: '0.11.6'
         runs-on:
         - ubuntu-latest
         - macos-latest


### PR DESCRIPTION
### What
Add cargo-edit.

### Why
To use in place of cargo workspaces for upgrading versions during the release process.