### PR TITLE
Add cargo-hack v0.5.28

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         - name: cargo-workspaces
           version: '0.2.35'
         - name: cargo-hack
-          version: '0.5.16'
+          version: '0.5.28'
         - name: cargo-set-rust-version
           version: '0.5.0'
         - name: cargo-edit


### PR DESCRIPTION
### What
Add cargo-hack v0.5.28.

### Why
Cargo-hack v0.5.28 adds a new option `--print-command-list` (https://github.com/taiki-e/cargo-hack/pull/175#issuecomment-1336348423). The option makes it possible to use cargo-hack to build a command list without actually executing the commands, as it does today.

This will allow us to build dynamic matrices for GitHub builds that are getting really big, like the stellar-xdr crate.

We've experimented with this feature pre-release in https://github.com/stellar/rs-stellar-xdr/pull/212.