### PR TITLE
Add cargo-fuzz v0.11.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,8 @@ jobs:
           version: '0.5.0'
         - name: cargo-edit
           version: '0.11.6'
+        - name: cargo-fuzz
+          version: '0.11.2'
         runs-on:
         - ubuntu-latest
         - macos-latest


### PR DESCRIPTION
### What
Add cargo-fuzz v0.11.2

### Why
For use in stellar/rs-soroban-sdk#957.