### PR TITLE
Add soroban-cli to binaries cached for ci builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,8 @@ jobs:
           version: '0.11.6'
         - name: cargo-fuzz
           version: '0.11.2'
+        - name: soroban-cli
+          version: '0.8.7'
         runs-on:
         - ubuntu-latest
         - macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
 
   cargo:
     strategy:
+      fail-fast: false
       matrix:
         crate:
         - name: cargo-workspaces


### PR DESCRIPTION
### What
Add soroban-cli to binaries cached for ci builds.

### Why
The soroban-examples repo will need soroban-cli installed in ci runs.