### PR TITLE
Add cargo-semver-checks and cargo-public-api

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,8 @@ jobs:
           version: '20.0.0-rc.4.1'
         - name: cargo-readme
           version: '3.3.1'
+        - name: cargo-semver-checks
+          version: '0.27.0'
         runs-on:
         - ubuntu-latest
         - macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,8 @@ jobs:
           version: '3.3.1'
         - name: cargo-semver-checks
           version: '0.27.0'
+        - name: cargo-public-api
+          version: '0.33.1'
         runs-on:
         - ubuntu-latest
         - macos-latest


### PR DESCRIPTION
### What
Add cargo-semver-checks and cargo-public-api.

### Why
For use in the rs-soroban-sdk CI for identifying breakages in the API compatibility of the library. Experimenting with both.

For stellar/rs-soroban-sdk#1195