### PR TITLE
Update cargo-fuzz to 0.12.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         - name: cargo-edit
           version: '0.11.6'
         - name: cargo-fuzz
-          version: '0.11.2'
+          version: '0.12.0'
         - name: soroban-cli
           version: '20.0.0-rc.4.1'
         - name: cargo-readme


### PR DESCRIPTION
### What
Update cargo-fuzz to 0.12.0

### Why
Use the latest version in a soroban-sdk job that is failing with an error when using a newer version of rust.