### PR TITLE
Add wasm-pack 0.12.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,8 @@ jobs:
           version: '0.27.0'
         - name: cargo-public-api
           version: '0.33.1'
+        - name: wasm-pack
+          version: '0.12.1'
         runs-on:
         - ubuntu-latest
         - macos-latest


### PR DESCRIPTION
### What
Add wasm-pack 0.12.1

### Why
For use in the rs-stellar-xdr repo to generate language bindings for JavaScript.