### PR TITLE
Build binaries for macOS amd64 and arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         runs-on:
         - ubuntu-latest
         - macos-14
-        - macos-14-arm
+        - macos-14-arm64
         - windows-latest
     runs-on: ${{ matrix.runs-on }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
           version: '0.12.1'
         runs-on:
         - ubuntu-latest
-        - macos-13 # x86
+        - macos-13 # amd64
         - macos-14 # arm64
         - windows-latest
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
           version: '0.12.1'
         runs-on:
         - ubuntu-latest
-        - macos-13 # amd64
+        - macos-12 # amd64
         - macos-14 # arm64
         - windows-latest
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,8 @@ jobs:
           version: '0.12.1'
         runs-on:
         - ubuntu-latest
-        - macos-latest
+        - macos-14
+        - macos-14-arm
         - windows-latest
     runs-on: ${{ matrix.runs-on }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,8 +45,8 @@ jobs:
           version: '0.12.1'
         runs-on:
         - ubuntu-latest
-        - macos-14
-        - macos-14-arm64
+        - macos-13 # x86
+        - macos-14 # arm64
         - windows-latest
     runs-on: ${{ matrix.runs-on }}
     steps:


### PR DESCRIPTION
### What
Build binaries for macOS amd64 and arm64

### Why
I started to see builds fail because `macos-latest` appears to now map to `macos-14-arm` rather than `macos-14`. An example of a build I saw fail is: https://github.com/stellar/rs-soroban-sdk/actions/runs/8815533346/job/24197683380?pr=1261