### PR TITLE
Add check-lockfile-intersection to binaries list

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,8 @@ jobs:
           version: '0.33.1'
         - name: wasm-pack
           version: '0.12.1'
+        - name: check-lockfile-intersection
+          version: '0.1.0'
         runs-on:
         - ubuntu-latest
         - macos-12 # amd64


### PR DESCRIPTION
This is part of making https://github.com/stellar/rs-soroban-env/pull/1416 work -- we will need to run a new binary during CI