### PR TITLE
Add wasm-bindgen-cli v0.2.92

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,8 @@ jobs:
           version: '0.33.1'
         - name: wasm-pack
           version: '0.12.1'
+        - name: wasm-bindgen-cli
+          version: '0.2.92'
         - name: check-lockfile-intersection
           version: '0.1.0'
         runs-on:


### PR DESCRIPTION
### What

Add wasm-bindgen-cli v0.2.92.

### Why

To use alongside wasm-pack in the js-stellar-xdr-json library.

### Known limitations

N/A
