### PR TITLE
Bump cargo-semver-checks to 0.32.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         - name: cargo-readme
           version: '3.3.1'
         - name: cargo-semver-checks
-          version: '0.27.0'
+          version: '0.32.0'
         - name: cargo-public-api
           version: '0.33.1'
         - name: wasm-pack


### PR DESCRIPTION
### What

Fix CI breakage due to Rustdocs https://github.com/stellar/rs-soroban-env/actions/runs/9618744429/job/26533277451

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
