### PR TITLE
Add cargo-workspaces 0.3.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,8 @@ jobs:
         crate:
         - name: cargo-workspaces
           version: '0.2.35'
+        - name: cargo-workspaces
+          version: '0.3.4'
         - name: cargo-hack
           version: '0.5.28'
         - name: cargo-set-rust-version


### PR DESCRIPTION
### What

Add cargo-workspaces 0.3.4.

### Why

For use in the rust-publish-dry-run-v2 workflow in stellar/actions.
