### PR TITLE
Add CI concurrency group

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,10 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   complete:


### PR DESCRIPTION
### What

Add CI concurrency group limiting to one build per branch, including main, canceling any older runs.

### Why

Limit CI resource usage, especially of mac and windows instances. We never need out-of-date commit CI runs to complete, even on main.
