### PR TITLE
Make version of go builds consistent with cargo builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
         package:
         - name: actionlint
           import-path: github.com/rhysd/actionlint/cmd/actionlint
-          version: 'v1.7.1'
+          version: '1.7.1'
         runs-on:
         - ubuntu-latest
         - macos-12 # amd64
@@ -93,7 +93,7 @@ jobs:
       with:
         go-version: stable
     - shell: bash
-      run: GOBIN="$PWD/bin" go install ${{ matrix.package.import-path }}@${{ matrix.package.version }}
+      run: GOBIN="$PWD/bin" go install ${{ matrix.package.import-path }}@v${{ matrix.package.version }}
     - shell: bash
       run: tar cvfz ${{ matrix.package.name }}-${{ matrix.package.version }}-${{ runner.os }}-${{ runner.arch }}.tar.gz -C bin .
     - uses: actions/upload-artifact@v3


### PR DESCRIPTION
### What

Change the version of the go commands built so the version string is just "1.7.1" instead of "v1.7.1"

### Why

The version is used in the resulting file that gets uploaded to the releases.

The version of go builds has a v in the file name, and the version of cargo builds has no v in the filename.

For consistency with the cargo commands that are built.
