### PR TITLE
Bump cargo-semver-checks to 0.35

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         - name: cargo-readme
           version: '3.3.1'
         - name: cargo-semver-checks
-          version: '0.32.0'
+          version: '0.35.0'
         - name: cargo-public-api
           version: '0.33.1'
         - name: wasm-pack


### PR DESCRIPTION
semver-checks started failing on nightly due to changes in rustdoc's internals. see https://github.com/obi1kenobi/cargo-semver-checks/pull/825

