### PR TITLE
Bump cargo-semver-checks to 0.37.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
           version: '1.0.0'
         runs-on:
         - ubuntu-latest
-        - macos-12 # amd64
+        - macos-13 # arm64
         - macos-14 # arm64
         - windows-latest
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
           version: '1.7.1'
         runs-on:
         - ubuntu-latest
-        - macos-12 # amd64
+        - macos-13 # arm64
         - macos-14 # arm64
         - windows-latest
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         - name: cargo-readme
           version: '3.3.1'
         - name: cargo-semver-checks
-          version: '0.35.0'
+          version: '0.37.0'
         - name: cargo-public-api
           version: '0.33.1'
         - name: wasm-pack


### PR DESCRIPTION
### What

Bump cargo-semver-checks to 0.37.0

### Why

To fix Rust CI that expects the updated version

### Known limitations

N/A
