### PR TITLE
Bump cargo-hack

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,8 @@ jobs:
           version: '0.3.6'
         - name: cargo-hack
           version: '0.5.28'
+        - name: cargo-hack
+          version: '0.6.35'
         - name: cargo-set-rust-version
           version: '0.5.0'
         - name: cargo-edit


### PR DESCRIPTION
### What

Bumps cargo-hack version

### Why

We need latest cargo-hack version for dry-run.
Older version doesn't support properly 
See [build using latest cargo-hack](https://github.com/stellar/stellar-cli/actions/runs/13959029959/job/39076758170)
And [build using cargo hack currently in binaries](https://github.com/stellar/stellar-cli/actions/runs/13958168604/job/39074154587)
> warning: --ignore-unknown-features for --group-features is not fully implemented and may not work as intended

^
We are using combination of this 2 flags in cli's dry-run (and it doesn't work as intended in older versions :( )

### Known limitations

N/A