### PR TITLE
Update cargo-semver-checks to 0.40.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
         - name: cargo-readme
           version: '3.3.1'
         - name: cargo-semver-checks
-          version: '0.37.0'
+          version: '0.40.0'
         - name: cargo-public-api
           version: '0.33.1'
         - name: wasm-pack


### PR DESCRIPTION
### What

Update cargo-semver-checks to 0.40.0.

### Why

The version currently in use isn't compatible with newer versions of Rust.

Required for:
- https://github.com/stellar/rs-soroban-sdk/pull/1453
