### PR TITLE
Bump cargo-semver-checks to 0.41.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
         - name: cargo-readme
           version: '3.3.1'
         - name: cargo-semver-checks
-          version: '0.40.0'
+          version: '0.41.0'
         - name: cargo-public-api
           version: '0.33.1'
         - name: wasm-pack


### PR DESCRIPTION
### What

Bump cargo-semver-checks to 0.41.0

### Why

Fix Rust CI

### Known limitations

N/A
