### PR TITLE
Update cargo-fuzz to 0.13.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         - name: cargo-edit
           version: '0.11.6'
         - name: cargo-fuzz
-          version: '0.12.0'
+          version: '0.13.1'
         - name: cargo-deny
           version: '0.14.19'
           rust: '1.79.0'


### PR DESCRIPTION
### What

Update cargo-fuzz to 0.13.1.

### Why

Get latest version.
