### PR TITLE
Update cargo-semver-checks to 0.42.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
         - name: cargo-readme
           version: '3.3.1'
         - name: cargo-semver-checks
-          version: '0.41.0'
+          version: '0.42.0'
         - name: cargo-public-api
           version: '0.33.1'
         - name: wasm-pack


### PR DESCRIPTION
### What

Update cargo-semver-checks to 0.42.0.

### Why

Get latest version due to current version not compatible with latest Rust:
- https://github.com/stellar/rs-soroban-sdk/actions/runs/16814809806/job/47629188058?pr=1528
