### PR TITLE
Add cargo-expand 1.0.116

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,8 @@ jobs:
       fail-fast: false
       matrix:
         crate:
+        - name: cargo-expand
+          version: '1.0.116'
         - name: cargo-workspaces
           version: '0.2.35'
         - name: cargo-workspaces


### PR DESCRIPTION
### What

Add cargo-expand 1.0.116.

### Why

For use in the rs-soroban-sdk repo CI.

For https://github.com/stellar/rs-soroban-sdk/issues/1544