### PR TITLE
Reuse existing artifacts from prior releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,9 +70,8 @@ jobs:
     defaults:
       run:
         shell: bash
-    env:
-      ASSET_NAME: ${{ matrix.crate.name }}-${{ matrix.crate.version }}-${{ runner.os }}-${{ runner.arch }}.tar.gz
     steps:
+    - run: echo "ASSET_NAME=${{ matrix.package.name }}-${{ matrix.package.version }}-${{ runner.os }}-${{ runner.arch }}.tar.gz" >> $GITHUB_ENV
     - name: Check for existing artifact
       id: check
       run: |
@@ -120,9 +119,8 @@ jobs:
     defaults:
       run:
         shell: bash
-    env:
-      ASSET_NAME: ${{ matrix.package.name }}-${{ matrix.package.version }}-${{ runner.os }}-${{ runner.arch }}.tar.gz
     steps:
+    - run: echo "ASSET_NAME=${{ matrix.package.name }}-${{ matrix.package.version }}-${{ runner.os }}-${{ runner.arch }}.tar.gz" >> $GITHUB_ENV
     - name: Check for existing artifact
       run: |
         TAG=$(gh release list --limit 1 --json tagName | jq -r '.[0].tagName')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
       run: |
         rustup install ${{ matrix.crate.rust }}
         rustup default ${{ matrix.crate.rust }}
-    - if: steps.check.outputs.exists == 'false' && !matrix.crate.rust'
+    - if: steps.check.outputs.exists == 'false' && !matrix.crate.rust
       run: |
         rustup update
         rustc -V

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,8 +75,8 @@ jobs:
     - name: Check for existing artifact
       id: check
       run: |
-        TAG=$(gh release list --limit 1 --json tagName | jq -r '.[0].tagName')
-        if gh release download $TAG --pattern "$ASSET_NAME"; then
+        TAG=$(gh release list -R ${{ github.repository }} --limit 1 --json tagName | jq -r '.[0].tagName')
+        if gh release download -R ${{ github.repository }} $TAG --pattern "$ASSET_NAME"; then
           echo "exists=true" >> $GITHUB_OUTPUT
         else
           echo "exists=false" >> $GITHUB_OUTPUT
@@ -123,8 +123,8 @@ jobs:
     - run: echo "ASSET_NAME=${{ matrix.package.name }}-${{ matrix.package.version }}-${{ runner.os }}-${{ runner.arch }}.tar.gz" >> $GITHUB_ENV
     - name: Check for existing artifact
       run: |
-        TAG=$(gh release list --limit 1 --json tagName | jq -r '.[0].tagName')
-        if gh release download $TAG --pattern "$ASSET_NAME"; then
+        TAG=$(gh release list -R ${{ github.repository }} --limit 1 --json tagName | jq -r '.[0].tagName')
+        if gh release download -R ${{ github.repository }} $TAG --pattern "$ASSET_NAME"; then
           echo "exists=true" >> $GITHUB_OUTPUT
         else
           echo "exists=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
       run:
         shell: bash
     steps:
-    - run: echo "ASSET_NAME=${{ matrix.package.name }}-${{ matrix.package.version }}-${{ runner.os }}-${{ runner.arch }}.tar.gz" >> $GITHUB_ENV
+    - run: echo "ASSET_NAME=${{ matrix.crate.name }}-${{ matrix.crate.version }}-${{ runner.os }}-${{ runner.arch }}.tar.gz" >> $GITHUB_ENV
     - name: Check for existing artifact
       id: check
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,25 +67,37 @@ jobs:
         - macos-14 # arm64
         - windows-latest
     runs-on: ${{ matrix.runs-on }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      ASSET_NAME: ${{ matrix.crate.name }}-${{ matrix.crate.version }}-${{ runner.os }}-${{ runner.arch }}.tar.gz
     steps:
-    - uses: actions/checkout@v3
-    - if: 'matrix.crate.rust'
-      shell: bash
+    - name: Check for existing artifact
+      id: check
+      run: |
+        TAG=$(gh release list --limit 1 --json tagName | jq -r '.[0].tagName')
+        if gh release download $TAG --pattern "$ASSET_NAME"; then
+          echo "exists=true" >> $GITHUB_OUTPUT
+        else
+          echo "exists=false" >> $GITHUB_OUTPUT
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - if: steps.check.outputs.exists == 'false' && matrix.crate.rust
       run: |
         rustup install ${{ matrix.crate.rust }}
         rustup default ${{ matrix.crate.rust }}
-    - if: '!matrix.crate.rust'
-      shell: bash
-      run: rustup update
-    - shell: bash
+    - if: steps.check.outputs.exists == 'false' && !matrix.crate.rust'
       run: |
+        rustup update
         rustc -V
-        cargo -V
-    - uses: stellar/actions/rust-cache@main
-    - shell: bash
+    - if: steps.check.outputs.exists == 'false'
+      uses: stellar/actions/rust-cache@main
+    - if: steps.check.outputs.exists == 'false'
       run: cargo install --target-dir ~/.cargo/target --root . --locked --version ${{ matrix.crate.version }} ${{ matrix.crate.name }}
-    - shell: bash
-      run: tar cvfz ${{ matrix.crate.name }}-${{ matrix.crate.version }}-${{ runner.os }}-${{ runner.arch }}.tar.gz -C bin .
+    - if: steps.check.outputs.exists == 'false'
+      run: tar cvfz $ASSET_NAME -C bin .
     - uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.crate.name }}-${{ matrix.crate.version }}-${{ matrix.runs-on }}
@@ -105,15 +117,31 @@ jobs:
         - macos-14 # arm64
         - windows-latest
     runs-on: ${{ matrix.runs-on }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      ASSET_NAME: ${{ matrix.package.name }}-${{ matrix.package.version }}-${{ runner.os }}-${{ runner.arch }}.tar.gz
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-go@v5
+    - name: Check for existing artifact
+      run: |
+        TAG=$(gh release list --limit 1 --json tagName | jq -r '.[0].tagName')
+        if gh release download $TAG --pattern "$ASSET_NAME"; then
+          echo "exists=true" >> $GITHUB_OUTPUT
+        else
+          echo "exists=false" >> $GITHUB_OUTPUT
+        fi
+      id: check
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - if: steps.check.outputs.exists == 'false'
+      uses: actions/setup-go@v5
       with:
         go-version: stable
-    - shell: bash
+    - if: steps.check.outputs.exists == 'false'
       run: GOBIN="$PWD/bin" go install ${{ matrix.package.import-path }}@v${{ matrix.package.version }}
-    - shell: bash
-      run: tar cvfz ${{ matrix.package.name }}-${{ matrix.package.version }}-${{ runner.os }}-${{ runner.arch }}.tar.gz -C bin .
+    - if: steps.check.outputs.exists == 'false'
+      run: tar cvfz $ASSET_NAME -C bin .
     - uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.package.name }}-${{ matrix.package.version }}-${{ matrix.runs-on }}


### PR DESCRIPTION
### What
  Check for and reuse existing release artifacts before rebuilding. Only build new versions.

  ### Why
  Reduce build times and resource usage by skipping redundant compilation and packaging steps when artifacts already exist in previous releases.