### PR TITLE
Fix release-test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,7 +188,7 @@ jobs:
         shell: bash
     steps:
     - uses: actions/checkout@v5
-    - uses: ./action.yml
+    - uses: ./
       with:
         name: wasm-cs
         version: 1.0.0


### PR DESCRIPTION
### What

Change the release test to reference the action using the directory, not the filename.

### Why

Actions are referenced locally as a directory, not a filename.
