### PR TITLE
Install cargo plugins to .cargo/bin directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,15 +10,27 @@ inputs:
 runs:
   using: "composite"
   steps:
+  - name: Determine Install Path
+    shell: bash
+    run: |
+      # Tools beginning with 'cargo-' are intended to be used as a plugin for
+      # cargo. For some reason in GitHub Actions Window's runners cargo only
+      # finds plugins installed in the .cargo/bin directory, and not other bin
+      # directories even if they are located on the path.
+      if [[ "${{ inputs.name }}" == cargo-* ]]; then
+        echo "INSTALL_PATH=$HOME/.cargo/bin" >> $GITHUB_ENV
+      else
+        echo "INSTALL_PATH=$HOME/.local/bin" >> $GITHUB_ENV
+      fi
   - name: Setup Install Location
     shell: bash
     run: |
-      mkdir -p $HOME/.local/bin
-      echo "$HOME/.local/bin" >> $GITHUB_PATH
+      mkdir -p $INSTALL_PATH
+      echo "$INSTALL_PATH" >> $GITHUB_PATH
   - shell: bash
     env:
       REF: ${{ github.action_ref }}
     run: |
       file="${{ inputs.name }}-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}.tar.gz"
       ref="${{ inputs.ref || env.REF }}"
-      curl -fL https://github.com/stellar/binaries/releases/download/$ref/$file | tar xvz -C $HOME/.local/bin
+      curl -fL https://github.com/stellar/binaries/releases/download/$ref/$file | tar xvz -C $INSTALL_PATH


### PR DESCRIPTION
### What
  Install cargo plugins, tools beginning with 'cargo-' prefix, to the .cargo/bin.

  ### Why
  Cargo plugins must be installed in .cargo/bin to be recognized by cargo's plugin system on GitHub Actions Windows runners. At least that's what it seems like. I've burnt a lot of time trying to debug this and when I place binaries into that directory they get picked up by the cargo plugin system, and no otherwise, even if they are in places that are clearly on the PATH.

We have historically worked around this issue for any GitHub workflow that runs on a Windows runner, by running plugin commands directly instead of via the cargo command. But this has limitations which I'm running into on a change I'm pushing to the rs-soroban-sdk repo. The main limitation is you can't use the rustup rust-version-selection on cargo commands, like `cargo +1.84.0 ...`. 