### PR TITLE
Update macOS runner versions to latest and add Linux arm64 support for Go builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,8 +65,8 @@ jobs:
         runs-on:
         - ubuntu-latest
         - ubuntu-22.04-arm
-        - macos-13 # x64
-        - macos-14 # arm64
+        - macos-15-intel # x64
+        - macos-latest # arm64
         - windows-latest
     runs-on: ${{ matrix.runs-on }}
     defaults:
@@ -114,8 +114,9 @@ jobs:
           version: '1.7.1'
         runs-on:
         - ubuntu-latest
-        - macos-13 # arm64
-        - macos-14 # arm64
+        - ubuntu-22.04-arm
+        - macos-15-intel # arm64
+        - macos-latest # arm64
         - windows-latest
     runs-on: ${{ matrix.runs-on }}
     defaults:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,11 +63,11 @@ jobs:
         - name: wasm-cs
           version: '1.0.0'
         runs-on:
-        - ubuntu-latest
-        - ubuntu-22.04-arm
-        - macos-15-intel # x64
+        - ubuntu-latest # amd64
+        - ubuntu-22.04-arm # arm64
+        - macos-15-intel # amd64
         - macos-latest # arm64
-        - windows-latest
+        - windows-latest # amd64
     runs-on: ${{ matrix.runs-on }}
     defaults:
       run:
@@ -113,11 +113,11 @@ jobs:
           import-path: github.com/rhysd/actionlint/cmd/actionlint
           version: '1.7.1'
         runs-on:
-        - ubuntu-latest
-        - ubuntu-22.04-arm
-        - macos-15-intel # arm64
+        - ubuntu-latest # amd64
+        - ubuntu-22.04-arm # arm64
+        - macos-15-intel # amd64
         - macos-latest # arm64
-        - windows-latest
+        - windows-latest # amd64
     runs-on: ${{ matrix.runs-on }}
     defaults:
       run:
@@ -180,9 +180,11 @@ jobs:
     strategy:
       matrix:
         runs-on:
-        - ubuntu-latest
-        - macos-latest
-        - windows-latest
+        - ubuntu-latest # amd64
+        - ubuntu-22.04-arm # arm64
+        - macos-15-intel # amd64
+        - macos-latest # arm64
+        - windows-latest # amd64
     runs-on: ${{ matrix.runs-on }}
     defaults:
       run:


### PR DESCRIPTION
### What
  Update macOS runner versions to latest and add Linux arm64 support for Go builds.

  ### Why
  Use latest macOS runners for better compatibility and performance. The arm64 Linux use on Go builds was missing.