### PR TITLE
Update cargo-hack to 0.6.44

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,7 @@ jobs:
         - name: cargo-workspaces
           version: '0.3.6'
         - name: cargo-hack
-          version: '0.5.28'
-        - name: cargo-hack
-          version: '0.6.35'
+          version: '0.6.44'
         - name: cargo-set-rust-version
           version: '0.5.0'
         - name: cargo-edit


### PR DESCRIPTION
### What
Bump cargo-hack to 0.6.44 and drop the older 0.5.28 and 0.6.35 builds from the build matrix.

### Why
Publish the current cargo-hack release and stop maintaining superseded versions.