### PR TITLE
Add Renovate for automated tool updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,8 @@ jobs:
 
   cargo:
     needs: prepare
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -83,6 +85,8 @@ jobs:
 
   go:
     needs: prepare
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,8 @@ jobs:
     - uses: actions/checkout@v5
     - id: matrix
       run: |
-        echo "cargo=$(jq -c '.cargo' tools/tools.json)" >> "$GITHUB_OUTPUT"
-        echo "go=$(jq -c '.go' tools/tools.json)" >> "$GITHUB_OUTPUT"
+        echo "cargo=$(jq -c '.cargo' tools-cargo.json)" >> "$GITHUB_OUTPUT"
+        echo "go=$(jq -c '.go' tools-go.json)" >> "$GITHUB_OUTPUT"
 
   cargo:
     needs: prepare

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,8 @@ jobs:
     - uses: actions/checkout@v5
     - id: matrix
       run: |
-        echo "cargo=$(jq -c '.cargo' tools-cargo.json)" >> "$GITHUB_OUTPUT"
-        echo "go=$(jq -c '.go' tools-go.json)" >> "$GITHUB_OUTPUT"
+        echo "cargo=$(jq -c '.' tools-cargo.json)" >> "$GITHUB_OUTPUT"
+        echo "go=$(jq -c '.' tools-go.json)" >> "$GITHUB_OUTPUT"
 
   cargo:
     needs: prepare

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,58 +16,30 @@ jobs:
 
   complete:
     if: always()
-    needs: [cargo, go]
+    needs: [prepare, cargo, go]
     runs-on: ubuntu-latest
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
       run: exit 1
 
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      cargo: ${{ steps.matrix.outputs.cargo }}
+      go: ${{ steps.matrix.outputs.go }}
+    steps:
+    - uses: actions/checkout@v5
+    - id: matrix
+      run: |
+        echo "cargo=$(jq -c '.cargo' tools/tools.json)" >> "$GITHUB_OUTPUT"
+        echo "go=$(jq -c '.go' tools/tools.json)" >> "$GITHUB_OUTPUT"
+
   cargo:
+    needs: prepare
     strategy:
       fail-fast: false
       matrix:
-        crate:
-        - name: cargo-expand
-          version: '1.0.116'
-        - name: cargo-workspaces
-          version: '0.2.35'
-        - name: cargo-workspaces
-          version: '0.3.6'
-        - name: cargo-hack
-          version: '0.6.44'
-        - name: cargo-set-rust-version
-          version: '0.5.0'
-        - name: cargo-edit
-          version: '0.11.6'
-        - name: cargo-fuzz
-          version: '0.13.1'
-        - name: cargo-deny
-          version: '0.14.19'
-          rust: '1.79.0'
-        - name: cargo-deny
-          version: '0.19.0'
-        - name: cargo-cache
-          version: '0.8.3'
-        - name: cargo-sweep
-          version: '0.7.0'
-        - name: cargo-readme
-          version: '3.3.1'
-        - name: cargo-semver-checks
-          version: '0.46.0'
-        - name: cargo-public-api
-          version: '0.33.1'
-        - name: cargo-nextest
-          version: '0.9.105'
-        - name: wasm-pack
-          version: '0.13.0'
-        - name: wasm-bindgen-cli
-          version: '0.2.92'
-        - name: check-lockfile-intersection
-          version: '0.1.0'
-        - name: wasm-cs
-          version: '1.0.0'
-        - name: sccache
-          version: '0.14.0'
+        crate: ${{ fromJSON(needs.prepare.outputs.cargo) }}
         runs-on:
         - ubuntu-latest # amd64
         - ubuntu-22.04-arm # arm64
@@ -111,13 +83,11 @@ jobs:
         path: '*.tar.gz'
 
   go:
+    needs: prepare
     strategy:
       fail-fast: false
       matrix:
-        package:
-        - name: actionlint
-          import-path: github.com/rhysd/actionlint/cmd/actionlint
-          version: '1.7.1'
+        package: ${{ fromJSON(needs.prepare.outputs.go) }}
         runs-on:
         - ubuntu-latest # amd64
         - ubuntu-22.04-arm # arm64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
 
   complete:
@@ -23,6 +25,8 @@ jobs:
 
   prepare:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       cargo: ${{ steps.matrix.outputs.cargo }}
       go: ${{ steps.matrix.outputs.go }}
@@ -131,6 +135,8 @@ jobs:
     if: github.ref_name == 'main'
     needs: complete
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v6
       with:
@@ -147,6 +153,8 @@ jobs:
     if: github.ref_name == 'main'
     needs: release-create
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/download-artifact@v8
     - run: gh release -R ${{ github.repository }} upload --clobber "${{ needs.release-create.outputs.tag }}" **/*.tar.gz
@@ -156,6 +164,8 @@ jobs:
   release-test:
     if: github.ref_name == 'main'
     needs: [release-create, release-upload]
+    permissions:
+      contents: read
     strategy:
       matrix:
         runs-on:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 name: Build and Release
 
 on:
-  workflow_call:
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -20,9 +20,6 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-    # Check out so the branch's renovate.json5 is on disk and can be passed to
-    # Renovate directly, instead of Renovate fetching repo config from the
-    # default branch.
     - uses: actions/checkout@v5
     - uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 #v46.1.14
       with:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -22,3 +22,7 @@ jobs:
     - uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 #v46.1.14
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
+      env:
+        RENOVATE_REPOSITORIES: ${{ github.repository }}
+        RENOVATE_DRY_RUN: ${{ inputs.dryRun }}
+        LOG_LEVEL: ${{ inputs.dryRun && 'debug' || 'info' }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -4,6 +4,7 @@ on:
   schedule:
   - cron: '0 6 * * *' # daily, 06:00 UTC
   workflow_dispatch:
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -20,19 +20,24 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+    # Check out so the branch's renovate.json5 is on disk and can be passed to
+    # Renovate directly, instead of Renovate fetching repo config from the
+    # default branch.
+    - uses: actions/checkout@v5
     - uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 #v46.1.14
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
+        # Use the checked-out config (the branch being run on) as Renovate's
+        # config, mounted into the container — no config needed on the default
+        # branch.
+        configurationFile: renovate.json5
       env:
         RENOVATE_REPOSITORIES: ${{ github.repository }}
         # Operate on the branch that triggered the run (the PR's source branch
         # on pull_request, otherwise the branch the workflow ran on).
         RENOVATE_BASE_BRANCH_PATTERNS: '["${{ github.head_ref || github.ref_name }}"]'
-        # Read the config from that branch rather than only the default branch.
-        RENOVATE_USE_BASE_BRANCH_CONFIG: merge
-        # Don't disable the repo when the default branch has no config yet.
+        # Don't require a config on the default branch, and never onboard.
         RENOVATE_REQUIRE_CONFIG: optional
-        # Config is committed in-repo, so never run the onboarding PR flow.
         RENOVATE_ONBOARDING: 'false'
         # Dry run on pull requests.
         RENOVATE_DRY_RUN: ${{ github.event_name == 'pull_request' && 'full' || '' }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,23 @@
+name: Renovate
+
+on:
+  schedule:
+  - cron: '0 6 * * *' # daily, 06:00 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+
+  renovate:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+    - uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 #v46.1.14
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -24,18 +24,11 @@ jobs:
     - uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 #v46.1.14
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        # Use the checked-out config (the branch being run on) as Renovate's
-        # config, mounted into the container — no config needed on the default
-        # branch.
         configurationFile: renovate.json5
       env:
         RENOVATE_REPOSITORIES: ${{ github.repository }}
-        # Operate on the branch that triggered the run (the PR's source branch
-        # on pull_request, otherwise the branch the workflow ran on).
         RENOVATE_BASE_BRANCH_PATTERNS: '["${{ github.head_ref || github.ref_name }}"]'
-        # Don't require a config on the default branch, and never onboard.
         RENOVATE_REQUIRE_CONFIG: optional
         RENOVATE_ONBOARDING: 'false'
-        # Dry run on pull requests.
         RENOVATE_DRY_RUN: ${{ github.event_name == 'pull_request' && 'full' || '' }}
         LOG_LEVEL: ${{ github.event_name == 'pull_request' && 'debug' || 'info' }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions: {}
@@ -17,6 +17,7 @@ jobs:
   renovate:
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       pull-requests: write
     steps:
     - uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 #v46.1.14
@@ -24,5 +25,11 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
       env:
         RENOVATE_REPOSITORIES: ${{ github.repository }}
-        RENOVATE_DRY_RUN: ${{ inputs.dryRun }}
-        LOG_LEVEL: ${{ inputs.dryRun && 'debug' || 'info' }}
+        # Operate on the branch that triggered the run (the PR's source branch
+        # on pull_request, otherwise the branch the workflow ran on).
+        RENOVATE_BASE_BRANCH_PATTERNS: '["${{ github.head_ref || github.ref_name }}"]'
+        # Config is committed in-repo, so never run the onboarding PR flow.
+        RENOVATE_ONBOARDING: 'false'
+        # Dry run on pull requests.
+        RENOVATE_DRY_RUN: ${{ github.event_name == 'pull_request' && 'full' || '' }}
+        LOG_LEVEL: ${{ github.event_name == 'pull_request' && 'debug' || 'info' }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -28,6 +28,10 @@ jobs:
         # Operate on the branch that triggered the run (the PR's source branch
         # on pull_request, otherwise the branch the workflow ran on).
         RENOVATE_BASE_BRANCH_PATTERNS: '["${{ github.head_ref || github.ref_name }}"]'
+        # Read the config from that branch rather than only the default branch.
+        RENOVATE_USE_BASE_BRANCH_CONFIG: merge
+        # Don't disable the repo when the default branch has no config yet.
+        RENOVATE_REQUIRE_CONFIG: optional
         # Config is committed in-repo, so never run the onboarding PR flow.
         RENOVATE_ONBOARDING: 'false'
         # Dry run on pull requests.

--- a/renovate.json5
+++ b/renovate.json5
@@ -7,10 +7,10 @@
   // manager off to avoid the two bots fighting.
   enabledManagers: ['custom.jsonata'],
 
-  // Hold every update until the release is at least 7 days old, and always
+  // Hold every update until the release is at least 1 month old, and always
   // target the newest version that passes that age check rather than the
   // absolute latest (so we never jump onto a brand-new release).
-  minimumReleaseAge: '7 days',
+  minimumReleaseAge: '1 month',
   internalChecksFilter: 'strict',
 
   customManagers: [

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,29 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: ['config:recommended'],
+
+  // Hold every update until the release is at least 7 days old, and always
+  // target the newest version that passes that age check rather than the
+  // absolute latest (so we never jump onto a brand-new release).
+  minimumReleaseAge: '7 days',
+  internalChecksFilter: 'strict',
+
+  customManagers: [
+    {
+      // cargo tools installed via `cargo install` in the build matrix.
+      customType: 'regex',
+      managerFilePatterns: ['/^\\.github/workflows/build\\.yml$/'],
+      matchStrings: ["name: (?<depName>[\\w-]+)\\s+version: '(?<currentValue>[^']+)'"],
+      datasourceTemplate: 'crate',
+    },
+    {
+      // go tools installed via `go install` in the build matrix. The version is
+      // stored without a leading `v`, so strip it from the upstream tag.
+      customType: 'regex',
+      managerFilePatterns: ['/^\\.github/workflows/build\\.yml$/'],
+      matchStrings: ["import-path: (?<depName>github\\.com/[^/\\s]+/[^/\\s]+)[^\\n]*\\s+version: '(?<currentValue>[^']+)'"],
+      datasourceTemplate: 'go',
+      extractVersionTemplate: '^v?(?<version>.+)$',
+    },
+  ],
+}

--- a/renovate.json5
+++ b/renovate.json5
@@ -2,6 +2,11 @@
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: ['config:recommended'],
 
+  // Only manage the tool versions in tools/tools.json. Action `uses:` pins are
+  // handled by Dependabot (.github/dependabot.yml), so leave every other
+  // manager off to avoid the two bots fighting.
+  enabledManagers: ['custom.jsonata'],
+
   // Hold every update until the release is at least 7 days old, and always
   // target the newest version that passes that age check rather than the
   // absolute latest (so we never jump onto a brand-new release).
@@ -10,20 +15,38 @@
 
   customManagers: [
     {
-      // cargo tools installed via `cargo install` in the build matrix.
-      customType: 'regex',
-      managerFilePatterns: ['/^\\.github/workflows/build\\.yml$/'],
-      matchStrings: ["name: (?<depName>[\\w-]+)\\s+version: '(?<currentValue>[^']+)'"],
+      // cargo tools built via `cargo install`. Parsed as structured JSON, so an
+      // optional `auto-update` flag anywhere in the entry is captured as the
+      // depType (see packageRules below) regardless of field order.
+      customType: 'jsonata',
+      fileFormat: 'json',
+      managerFilePatterns: ['/^tools/tools\\.json$/'],
+      matchStrings: [
+        'cargo.{ "depName": name, "currentValue": version, "depType": $string(`auto-update`) }',
+      ],
       datasourceTemplate: 'crate',
     },
     {
-      // go tools installed via `go install` in the build matrix. The version is
-      // stored without a leading `v`, so strip it from the upstream tag.
-      customType: 'regex',
-      managerFilePatterns: ['/^\\.github/workflows/build\\.yml$/'],
-      matchStrings: ["import-path: (?<depName>github\\.com/[^/\\s]+/[^/\\s]+)[^\\n]*\\s+version: '(?<currentValue>[^']+)'"],
+      // go tools built via `go install`. depName is the module root (first three
+      // path segments of import-path); version is stored without a leading `v`.
+      customType: 'jsonata',
+      fileFormat: 'json',
+      managerFilePatterns: ['/^tools/tools\\.json$/'],
+      matchStrings: [
+        'go.{ "depName": $join($split(`import-path`, "/")[[0..2]], "/"), "currentValue": version, "depType": $string(`auto-update`) }',
+      ],
       datasourceTemplate: 'go',
       extractVersionTemplate: '^v?(?<version>.+)$',
+    },
+  ],
+
+  packageRules: [
+    {
+      // Freeze a tool by setting "auto-update": false on its entry in
+      // tools/tools.json; that flag is captured as the depType above and
+      // disabled here, so Renovate never proposes updates for it.
+      matchDepTypes: ['false'],
+      enabled: false,
     },
   ],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -22,7 +22,7 @@
       fileFormat: 'json',
       managerFilePatterns: ['/^tools-cargo\\.json$/'],
       matchStrings: [
-        'cargo.{ "depName": name, "currentValue": version, "depType": $string(`auto-update`) }',
+        '$.{ "depName": name, "currentValue": version, "depType": $string(`auto-update`) }',
       ],
       datasourceTemplate: 'crate',
     },
@@ -33,7 +33,7 @@
       fileFormat: 'json',
       managerFilePatterns: ['/^tools-go\\.json$/'],
       matchStrings: [
-        'go.{ "depName": $join($split(`import-path`, "/")[[0..2]], "/"), "currentValue": version, "depType": $string(`auto-update`) }',
+        '$.{ "depName": $join($split(`import-path`, "/")[[0..2]], "/"), "currentValue": version, "depType": $string(`auto-update`) }',
       ],
       datasourceTemplate: 'go',
       extractVersionTemplate: '^v?(?<version>.+)$',

--- a/renovate.json5
+++ b/renovate.json5
@@ -20,7 +20,7 @@
       // depType (see packageRules below) regardless of field order.
       customType: 'jsonata',
       fileFormat: 'json',
-      managerFilePatterns: ['/^tools/tools\\.json$/'],
+      managerFilePatterns: ['/^tools-cargo\\.json$/'],
       matchStrings: [
         'cargo.{ "depName": name, "currentValue": version, "depType": $string(`auto-update`) }',
       ],
@@ -31,7 +31,7 @@
       // path segments of import-path); version is stored without a leading `v`.
       customType: 'jsonata',
       fileFormat: 'json',
-      managerFilePatterns: ['/^tools/tools\\.json$/'],
+      managerFilePatterns: ['/^tools-go\\.json$/'],
       matchStrings: [
         'go.{ "depName": $join($split(`import-path`, "/")[[0..2]], "/"), "currentValue": version, "depType": $string(`auto-update`) }',
       ],

--- a/tools-cargo.json
+++ b/tools-cargo.json
@@ -1,25 +1,22 @@
-{
-  "$comment": "Cargo tools built and released by .github/workflows/build.yml via `cargo install`. Renovate keeps `version` current (crates.io). Add \"auto-update\": false to freeze a row (e.g. a compatibility version kept alongside a newer one). The build matrix is generated straight from this file.",
-  "cargo": [
-    { "name": "cargo-expand", "version": "1.0.116" },
-    { "name": "cargo-workspaces", "version": "0.2.35", "auto-update": false },
-    { "name": "cargo-workspaces", "version": "0.3.6" },
-    { "name": "cargo-hack", "version": "0.6.44" },
-    { "name": "cargo-set-rust-version", "version": "0.5.0" },
-    { "name": "cargo-edit", "version": "0.11.6" },
-    { "name": "cargo-fuzz", "version": "0.13.1" },
-    { "name": "cargo-deny", "version": "0.14.19", "rust": "1.79.0", "auto-update": false },
-    { "name": "cargo-deny", "version": "0.19.0" },
-    { "name": "cargo-cache", "version": "0.8.3" },
-    { "name": "cargo-sweep", "version": "0.7.0" },
-    { "name": "cargo-readme", "version": "3.3.1" },
-    { "name": "cargo-semver-checks", "version": "0.46.0" },
-    { "name": "cargo-public-api", "version": "0.33.1" },
-    { "name": "cargo-nextest", "version": "0.9.105" },
-    { "name": "wasm-pack", "version": "0.13.0" },
-    { "name": "wasm-bindgen-cli", "version": "0.2.92" },
-    { "name": "check-lockfile-intersection", "version": "0.1.0" },
-    { "name": "wasm-cs", "version": "1.0.0" },
-    { "name": "sccache", "version": "0.14.0" }
-  ]
-}
+[
+  { "name": "cargo-expand", "version": "1.0.116" },
+  { "name": "cargo-workspaces", "version": "0.2.35", "auto-update": false },
+  { "name": "cargo-workspaces", "version": "0.3.6" },
+  { "name": "cargo-hack", "version": "0.6.44" },
+  { "name": "cargo-set-rust-version", "version": "0.5.0" },
+  { "name": "cargo-edit", "version": "0.11.6" },
+  { "name": "cargo-fuzz", "version": "0.13.1" },
+  { "name": "cargo-deny", "version": "0.14.19", "rust": "1.79.0", "auto-update": false },
+  { "name": "cargo-deny", "version": "0.19.0" },
+  { "name": "cargo-cache", "version": "0.8.3" },
+  { "name": "cargo-sweep", "version": "0.7.0" },
+  { "name": "cargo-readme", "version": "3.3.1" },
+  { "name": "cargo-semver-checks", "version": "0.46.0" },
+  { "name": "cargo-public-api", "version": "0.33.1" },
+  { "name": "cargo-nextest", "version": "0.9.105" },
+  { "name": "wasm-pack", "version": "0.13.0" },
+  { "name": "wasm-bindgen-cli", "version": "0.2.92" },
+  { "name": "check-lockfile-intersection", "version": "0.1.0" },
+  { "name": "wasm-cs", "version": "1.0.0" },
+  { "name": "sccache", "version": "0.14.0" }
+]

--- a/tools-cargo.json
+++ b/tools-cargo.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Tool versions built and released by .github/workflows/build.yml. Renovate keeps `version` current (cargo -> crates.io, go -> Go proxy). Add \"auto-update\": false to freeze a row (e.g. a compatibility version kept alongside a newer one). The build matrix is generated straight from this file.",
+  "$comment": "Cargo tools built and released by .github/workflows/build.yml via `cargo install`. Renovate keeps `version` current (crates.io). Add \"auto-update\": false to freeze a row (e.g. a compatibility version kept alongside a newer one). The build matrix is generated straight from this file.",
   "cargo": [
     { "name": "cargo-expand", "version": "1.0.116" },
     { "name": "cargo-workspaces", "version": "0.2.35", "auto-update": false },
@@ -21,8 +21,5 @@
     { "name": "check-lockfile-intersection", "version": "0.1.0" },
     { "name": "wasm-cs", "version": "1.0.0" },
     { "name": "sccache", "version": "0.14.0" }
-  ],
-  "go": [
-    { "name": "actionlint", "import-path": "github.com/rhysd/actionlint/cmd/actionlint", "version": "1.7.1" }
   ]
 }

--- a/tools-cargo.json
+++ b/tools-cargo.json
@@ -17,6 +17,6 @@
   { "name": "wasm-pack", "version": "0.13.0" },
   { "name": "wasm-bindgen-cli", "version": "0.2.92" },
   { "name": "check-lockfile-intersection", "version": "0.1.0" },
-  { "name": "wasm-cs", "version": "1.0.0" },
+  { "name": "wasm-cs", "version": "1.0.0", "auto-update": false },
   { "name": "sccache", "version": "0.14.0" }
 ]

--- a/tools-go.json
+++ b/tools-go.json
@@ -1,6 +1,3 @@
-{
-  "$comment": "Go tools built and released by .github/workflows/build.yml via `go install`. Renovate keeps `version` current (Go proxy). Add \"auto-update\": false to freeze a row. The build matrix is generated straight from this file.",
-  "go": [
-    { "name": "actionlint", "import-path": "github.com/rhysd/actionlint/cmd/actionlint", "version": "1.7.1" }
-  ]
-}
+[
+  { "name": "actionlint", "import-path": "github.com/rhysd/actionlint/cmd/actionlint", "version": "1.7.1" }
+]

--- a/tools-go.json
+++ b/tools-go.json
@@ -1,0 +1,6 @@
+{
+  "$comment": "Go tools built and released by .github/workflows/build.yml via `go install`. Renovate keeps `version` current (Go proxy). Add \"auto-update\": false to freeze a row. The build matrix is generated straight from this file.",
+  "go": [
+    { "name": "actionlint", "import-path": "github.com/rhysd/actionlint/cmd/actionlint", "version": "1.7.1" }
+  ]
+}

--- a/tools/tools.json
+++ b/tools/tools.json
@@ -1,0 +1,28 @@
+{
+  "$comment": "Tool versions built and released by .github/workflows/build.yml. Renovate keeps `version` current (cargo -> crates.io, go -> Go proxy). Add \"auto-update\": false to freeze a row (e.g. a compatibility version kept alongside a newer one). The build matrix is generated straight from this file.",
+  "cargo": [
+    { "name": "cargo-expand", "version": "1.0.116" },
+    { "name": "cargo-workspaces", "version": "0.2.35", "auto-update": false },
+    { "name": "cargo-workspaces", "version": "0.3.6" },
+    { "name": "cargo-hack", "version": "0.6.44" },
+    { "name": "cargo-set-rust-version", "version": "0.5.0" },
+    { "name": "cargo-edit", "version": "0.11.6" },
+    { "name": "cargo-fuzz", "version": "0.13.1" },
+    { "name": "cargo-deny", "version": "0.14.19", "rust": "1.79.0", "auto-update": false },
+    { "name": "cargo-deny", "version": "0.19.0" },
+    { "name": "cargo-cache", "version": "0.8.3" },
+    { "name": "cargo-sweep", "version": "0.7.0" },
+    { "name": "cargo-readme", "version": "3.3.1" },
+    { "name": "cargo-semver-checks", "version": "0.46.0" },
+    { "name": "cargo-public-api", "version": "0.33.1" },
+    { "name": "cargo-nextest", "version": "0.9.105" },
+    { "name": "wasm-pack", "version": "0.13.0" },
+    { "name": "wasm-bindgen-cli", "version": "0.2.92" },
+    { "name": "check-lockfile-intersection", "version": "0.1.0" },
+    { "name": "wasm-cs", "version": "1.0.0" },
+    { "name": "sccache", "version": "0.14.0" }
+  ],
+  "go": [
+    { "name": "actionlint", "import-path": "github.com/rhysd/actionlint/cmd/actionlint", "version": "1.7.1" }
+  ]
+}


### PR DESCRIPTION
### What
Add a daily Renovate GitHub Actions workflow that updates the versions of tools in the build workflow.

### Why
The build matrix pins tool versions in workflow YAML, and those tool versions quickly go out of date and updating them is today a manual annoying process. Renovate can update them. Renovate's default managers do not understand the build.yml file. A custom regex is used to find versions. The 7-day age gate avoids landing brand-new releases.