### PR TITLE
Grant Renovate statuses and checks perms

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -19,6 +19,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      statuses: write
+      checks: read
     steps:
     - uses: actions/checkout@v5
     - uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 #v46.1.14


### PR DESCRIPTION
### What

Grant the Renovate workflow job the `statuses: write` and `checks: read` token permissions in addition to the `contents: write` and `pull-requests: write` it already had.

### Why

Now that Renovate runs for real on `main` (rather than as a dry-run on PRs), it aborts on every run immediately after pushing its first branch, logging "Repository has changed during renovation - aborting" with `result: "repository-changed"`, and never opens any PRs. The base branch was not actually changing; the workflow's deliberately minimal `permissions` block set every unlisted scope to `none`, so when Renovate sets a commit status check on a branch it just pushed, the GitHub statuses API call fails, and Renovate's platform code converts any such failure into the generic `repository-changed` error and stops. Granting `statuses: write` lets that step succeed so Renovate can proceed to open its update PRs, and `checks: read` lets it read CI results on its own branches.

### Known limitations

This keeps the default `GITHUB_TOKEN`, which has two consequences that remain: PRs Renovate opens with this token will not trigger the `build.yml` CI workflow, and the token cannot modify files under `.github/workflows/`. If those matter, the remaining option is to run Renovate with a PAT or GitHub App token, as the original review feedback on the introducing PR suggested.

---
_Generated by [Claude Code](https://claude.ai/code/session_0192a5vsx5gskS3Td53At8UK)_