### PR TITLE
Disable Renovate vulnerability alerts

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -13,6 +13,12 @@
   minimumReleaseAge: '1 month',
   internalChecksFilter: 'strict',
 
+  // Disable Renovate's vulnerability-alert lookups; this repo doesn't use them
+  // (avoids the "Cannot access vulnerability alerts" warning in CI).
+  vulnerabilityAlerts: {
+    enabled: false,
+  },
+
   customManagers: [
     {
       // cargo tools built via `cargo install`. Parsed as structured JSON, so an


### PR DESCRIPTION
### What

Add a top-level `vulnerabilityAlerts` block to `renovate.json5` that turns the feature off.

### Why

Renovate's CI job emits a "Cannot access vulnerability alerts" warning because it attempts to read GitHub's vulnerability-alert data, which this repo does not grant access to or rely on. This config tightly scopes Renovate to managing tool versions, so the lookup is unnecessary noise; disabling it removes the warning.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LL3wxJTDQryrGLwBgsM6Pc)_