### PR TITLE
Disable Renovate dependency dashboard

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -13,6 +13,10 @@
   minimumReleaseAge: '1 month',
   internalChecksFilter: 'strict',
 
+  // Disable the Dependency Dashboard issue so Renovate doesn't need
+  // `issues: write` permission in the workflow.
+  dependencyDashboard: false,
+
   customManagers: [
     {
       // cargo tools built via `cargo install`. Parsed as structured JSON, so an


### PR DESCRIPTION
### What

Set `dependencyDashboard: false` in `renovate.json5` to turn off the Renovate Dependency Dashboard issue.

### Why

The Dependency Dashboard requires `issues: write` permission, which the Renovate workflow does not grant. This caused an "integration-unauthorized / Could not ensure issue" failure in CI. Disabling the dashboard removes the need for that permission and clears the failure.

### Known limitations

N/A

---
_Generated by [Claude Code](https://claude.ai/code/session_01LL3wxJTDQryrGLwBgsM6Pc)_