### PR TITLE
Pin crate tools to exact versions in Renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -58,6 +58,18 @@
 
   packageRules: [
     {
+      // The `crate` datasource defaults to Renovate's `cargo` versioning,
+      // which reads a bare value like "0.3.6" as a Cargo caret *requirement*
+      // (>=0.3.6, <0.4.0) rather than an exact pin. When the newest version
+      // falls outside that range, Renovate writes back the floor of the new
+      // range (e.g. "0.4.0") instead of the exact newest version it resolved
+      // (e.g. "0.4.2"). These entries are exact tool pins, so force `semver`
+      // versioning to make Renovate write the exact newest qualifying version.
+      // (`versioning` is disallowed on customManagers, so it lives here.)
+      matchDatasources: ['crate'],
+      versioning: 'semver',
+    },
+    {
       // Freeze a tool by setting "auto-update": false on its entry in
       // tools/tools.json; that flag is captured as the depType above and
       // disabled here, so Renovate never proposes updates for it.


### PR DESCRIPTION
### What

Add a Renovate `packageRule` that applies `semver` versioning to every dependency from the `crate` datasource, so the tool versions in `tools-cargo.json` are treated as exact pins.

### Why

Renovate's `crate` datasource defaults to `cargo` versioning, which reads a bare value like `0.3.6` as a Cargo caret requirement rather than an exact pin. When the newest qualifying release falls outside that implicit range, the `replace` strategy rewrites the value to the floor of the new caret series (e.g. `0.4.0`) instead of the version Renovate actually resolved (`0.4.2`). That is why PR #76 bumped `cargo-workspaces` to `0.4.0` rather than the latest `0.4.2`, and the same truncation affected other tools such as `cargo-edit` (`0.13.0` instead of `0.13.10`). The lookup was always resolving the correct latest version; only the value written to the file was wrong, so the earlier `separateMajorMinor`/`separateMinorPatch` changes could not address it. Forcing `semver` versioning makes each value an exact version, so Renovate writes the exact newest qualifying release. Verified with a local Renovate dry-run, which now produces `0.4.2` for `cargo-workspaces` and the exact latest for the other crate tools.

### Known limitations

Because every crate pin is now tracked as an exact version, tools that were previously held inside their implicit caret range (for example `cargo-deny`, `cargo-hack`, `cargo-nextest`) will start receiving update PRs toward their exact latest versions, so expect more Renovate PRs than before. This is the intended behaviour for a tools manifest. The `go` datasource is unaffected, since Go versioning already treats bare values as exact versions.