### PR TITLE
Run CI on merge group events

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
   release:
     types: [published]
 


### PR DESCRIPTION
### What

Add a merge_group trigger to the build workflow so the prepare, cargo, go, and aggregate complete jobs that already run on pull requests also run when a pull request is queued through GitHub's merge queue.

### Why

GitHub's merge queue validates queued pull requests against the latest target branch by dispatching merge_group events, but the workflow only listened for pull_request and push events, so it produced no status checks for queued entries and the queue had nothing to gate merges on. Listening for merge_group runs the identical build and test matrix against the speculative merge commit. The release jobs remain gated on github.ref_name == 'main', so a merge group run (whose ref is gh-readonly-queue/...) never publishes a release.

The change to enable the merge queue is at:
- https://github.com/stellar/terraform/pull/6269

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRaBpkdTsn8vX4kaNRfTBQ)_